### PR TITLE
Compute document age in sources

### DIFF
--- a/query_processor.py
+++ b/query_processor.py
@@ -259,7 +259,8 @@ Content: {content}
                         dt = datetime.fromisoformat(last_modified.replace("Z", "+00:00"))
                     else:
                         dt = datetime.fromisoformat(last_modified)
-                    days_old = (datetime.now(timezone.utc) - dt.astimezone(timezone.utc)).days
+                    delta = datetime.now(timezone.utc) - dt.astimezone(timezone.utc)
+                    days_old = max(delta.days, 0)
                 except Exception:
                     days_old = None
             

--- a/query_processor.py
+++ b/query_processor.py
@@ -247,14 +247,19 @@ Content: {content}
                 else:
                     excerpt = clean_content
             
-            # Format last modified date and calculate freshness
+            # Format last modified date
             formatted_date = self._format_date(last_modified)
+
+            # Calculate how many days old the document is
             days_old = None
-            if last_modified and last_modified != "Unknown" and "T" in last_modified:
+            if last_modified and last_modified != "Unknown":
+                from datetime import datetime, timezone
                 try:
-                    from datetime import datetime
-                    dt = datetime.fromisoformat(last_modified.replace("Z", "+00:00"))
-                    days_old = (datetime.now() - dt.replace(tzinfo=None)).days
+                    if "T" in last_modified:
+                        dt = datetime.fromisoformat(last_modified.replace("Z", "+00:00"))
+                    else:
+                        dt = datetime.fromisoformat(last_modified)
+                    days_old = (datetime.now(timezone.utc) - dt.astimezone(timezone.utc)).days
                 except Exception:
                     days_old = None
             

--- a/query_processor.py
+++ b/query_processor.py
@@ -268,8 +268,8 @@ Content: {content}
                 "url": url,
                 "source_type": source_type,
                 "last_updated": formatted_date,
+                "excerpt": excerpt or "No preview available",
                 "days_old": days_old,
-                "excerpt": excerpt or "No preview available"
             }
             
             sources.append(source_info)

--- a/query_processor.py
+++ b/query_processor.py
@@ -225,7 +225,9 @@ Content: {content}
             search_results: Raw search results from knowledge sources
             
         Returns:
-            Formatted sources for Teams adaptive cards
+            Formatted sources for Teams adaptive cards. Each entry includes
+            ``days_old`` representing how many days ago the document was last
+            modified.
         """
         sources = []
         

--- a/query_processor.py
+++ b/query_processor.py
@@ -247,14 +247,23 @@ Content: {content}
                 else:
                     excerpt = clean_content
             
-            # Format last modified date
+            # Format last modified date and calculate freshness
             formatted_date = self._format_date(last_modified)
+            days_old = None
+            if last_modified and last_modified != "Unknown" and "T" in last_modified:
+                try:
+                    from datetime import datetime
+                    dt = datetime.fromisoformat(last_modified.replace("Z", "+00:00"))
+                    days_old = (datetime.now() - dt.replace(tzinfo=None)).days
+                except Exception:
+                    days_old = None
             
             source_info = {
                 "title": title,
                 "url": url,
                 "source_type": source_type,
                 "last_updated": formatted_date,
+                "days_old": days_old,
                 "excerpt": excerpt or "No preview available"
             }
             

--- a/tests/test_query_processor.py
+++ b/tests/test_query_processor.py
@@ -1,19 +1,22 @@
-import os
 import sys
 import types
-from datetime import datetime, timezone
-from pathlib import Path
-
+import datetime
+import importlib
+import os
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-# Provide a stub AsyncOpenAI to avoid dependency on the real openai package
-class _DummyClient:
-    def __init__(self, *args, **kwargs):
-        pass
+# Stub external dependencies before importing the module under test
+openai_stub = types.ModuleType('openai')
+openai_stub.AsyncOpenAI = object
+sys.modules.setdefault('openai', openai_stub)
 
-sys.modules.setdefault("openai", types.SimpleNamespace(AsyncOpenAI=_DummyClient))
+aiohttp_stub = types.ModuleType('aiohttp')
+aiohttp_stub.ClientSession = object
+aiohttp_stub.ClientTimeout = object
+aiohttp_stub.ClientError = Exception
+sys.modules.setdefault('aiohttp', aiohttp_stub)
 
 # Stub knowledge source clients to avoid external dependencies
 class _DummySource:
@@ -28,23 +31,55 @@ sys.modules.setdefault("confluence_client", dummy_source_module)
 sys.modules.setdefault("sharepoint_client", types.SimpleNamespace(SharePointClient=_DummySource))
 sys.modules.setdefault("local_docs_client", types.SimpleNamespace(LocalDocsClient=_DummySource))
 
-from query_processor import QueryProcessor
+query_processor = importlib.import_module('query_processor')
+QueryProcessor = query_processor.QueryProcessor
+
+@pytest.fixture
+def qp():
+    # Create instance without invoking __init__
+    return QueryProcessor.__new__(QueryProcessor)
 
 
-def setup_query_processor():
-    os.environ.setdefault("OPENAI_API_KEY", "test")
-    return QueryProcessor()
+def test_format_date_iso(monkeypatch, qp):
+    fixed_now = datetime.datetime(2023, 1, 2, 12, 0, 0)
+
+    class FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(datetime, 'datetime', FixedDatetime)
+    result = qp._format_date('2023-01-01T12:00:00Z')
+    assert result == 'Yesterday'
 
 
-def test_format_sources_includes_days_old():
-    qp = setup_query_processor()
-    now = datetime.now(timezone.utc)
+@pytest.mark.parametrize('value', ['', 'Unknown'])
+def test_format_date_unknown_strings(qp, value):
+    assert qp._format_date(value) == 'Recently updated'
+
+
+def test_format_date_invalid_iso(monkeypatch, qp):
+    fixed_now = datetime.datetime(2023, 1, 2, 12, 0, 0)
+
+    class FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(datetime, 'datetime', FixedDatetime)
+    # Invalid month triggers fallback path
+    result = qp._format_date('2023-13-01T00:00:00Z')
+    assert result == 'Recently updated'
+
+
+def test_format_sources_includes_days_old(qp):
+    now = datetime.datetime.now(datetime.timezone.utc)
     iso_date = now.isoformat().replace('+00:00', 'Z')
     results = [{
-        "title": "Doc", 
-        "url": "http://example.com", 
-        "source": "Confluence", 
-        "last_modified": iso_date, 
+        "title": "Doc",
+        "url": "http://example.com",
+        "source": "Confluence",
+        "last_modified": iso_date,
         "content": "Example content"
     }]
     formatted = qp._format_sources(results)
@@ -55,8 +90,7 @@ def test_format_sources_includes_days_old():
     assert formatted[0]["excerpt"].startswith("Example content")
 
 
-def test_format_sources_handles_missing_date():
-    qp = setup_query_processor()
+def test_format_sources_handles_missing_date(qp):
     results = [{"title": "Doc", "url": "http://example.com", "source": "Confluence", "content": "Info"}]
     formatted = qp._format_sources(results)
     assert formatted[0]["days_old"] is None

--- a/tests/test_query_processor.py
+++ b/tests/test_query_processor.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide a stub AsyncOpenAI to avoid dependency on the real openai package
+class _DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+sys.modules.setdefault("openai", types.SimpleNamespace(AsyncOpenAI=_DummyClient))
+
+# Stub knowledge source clients to avoid external dependencies
+class _DummySource:
+    def __init__(self, *args, **kwargs):
+        self.enabled = False
+
+    async def search(self, *args, **kwargs):
+        return []
+
+dummy_source_module = types.SimpleNamespace(ConfluenceClient=_DummySource)
+sys.modules.setdefault("confluence_client", dummy_source_module)
+sys.modules.setdefault("sharepoint_client", types.SimpleNamespace(SharePointClient=_DummySource))
+sys.modules.setdefault("local_docs_client", types.SimpleNamespace(LocalDocsClient=_DummySource))
+
+from query_processor import QueryProcessor
+
+
+def setup_query_processor():
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    return QueryProcessor()
+
+
+def test_format_sources_includes_days_old():
+    qp = setup_query_processor()
+    now = datetime.now(timezone.utc)
+    iso_date = now.isoformat().replace('+00:00', 'Z')
+    results = [{
+        "title": "Doc", 
+        "url": "http://example.com", 
+        "source": "Confluence", 
+        "last_modified": iso_date, 
+        "content": "Example content"
+    }]
+    formatted = qp._format_sources(results)
+    assert formatted[0]["title"] == "Doc"
+    assert formatted[0]["url"] == "http://example.com"
+    assert formatted[0]["source_type"] == "Confluence"
+    assert formatted[0]["days_old"] == 0
+    assert formatted[0]["excerpt"].startswith("Example content")
+
+
+def test_format_sources_handles_missing_date():
+    qp = setup_query_processor()
+    results = [{"title": "Doc", "url": "http://example.com", "source": "Confluence", "content": "Info"}]
+    formatted = qp._format_sources(results)
+    assert formatted[0]["days_old"] is None
+    assert formatted[0]["last_updated"] == "Recently updated"

--- a/tests/test_query_processor.py
+++ b/tests/test_query_processor.py
@@ -2,7 +2,6 @@ import os
 import sys
 import types
 import datetime
-import importlib
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
## Summary
- add `days_old` freshness information in `_format_sources`
- update adaptive card freshness logic via the new key
- create unit tests for `_format_sources`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685445da454083278d35fe90fde42e58