### PR TITLE
Resolve conflicts and add document age tests

### DIFF
--- a/query_processor.py
+++ b/query_processor.py
@@ -223,12 +223,13 @@ Content: {content}
     def _format_sources(self, search_results: List[Dict]) -> List[Dict]:
         """
         Format sources for adaptive card display
-        
+
         Args:
             search_results: Raw search results from knowledge sources
-            
+
         Returns:
-            Formatted sources for Teams adaptive cards
+            Formatted sources for Teams adaptive cards. Each entry includes
+            ``days_old`` representing the document's age in days.
         """
         sources = []
         


### PR DESCRIPTION
## Summary
- document `days_old` return in `_format_sources`
- test `_format_sources` for `days_old` calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544b3af3d083279f647cb3e2e0f6e4